### PR TITLE
Add missing header include for gcc10/kali/debian10

### DIFF
--- a/src/crypto/equihash.h
+++ b/src/crypto/equihash.h
@@ -13,6 +13,7 @@
 #include "komodo_nk.h"
 
 #include <cstring>
+#include <stdexcept>
 #include <exception>
 #include <functional>
 #include <memory>


### PR DESCRIPTION
To successfully build on Kali Linux (Debian 10) with gcc-10, added missing include as per https://github.com/zcash/zcash/commit/08662fa09a14c68b1048ee4384b25dfd9ad0463f