### PR TITLE
Fix 2 segfaults for off-line transaction signing

### DIFF
--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -117,13 +117,9 @@ AsyncRPCOperation_sendmany::AsyncRPCOperation_sendmany(
 
     bOfflineSpendingKey=false;
     if (!isfromtaddr_) {
+        fromAddress_ = fromAddress; //Initialise private, persistant Address for the object.
         auto address = DecodePaymentAddress(fromAddress);
         if (IsValidPaymentAddress(address)) {
-            // We don't need to lock on the wallet as spending key related methods are thread-safe
-            if (!boost::apply_visitor(HaveSpendingKeyForPaymentAddress(pwalletMain), address)) {
-                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid from address, no spending key found for zaddr");
-            }
-
             isfromzaddr_ = true;
             frompaymentaddress_ = address;
             // We don't need to lock on the wallet as spending key related methods are thread-safe


### PR DESCRIPTION
Initialise class private variable: fromAddress_
Removed a double evaluation of "HaveSpendingKeyForPaymentAddress(pwalletMain), address))",
--Note: This must be split in an if() statement, evaluating if offline signing is enabled or not.
             The current implementation works for offline signing, but if that feature is disabled,
             the original implementation, which rejects if you don't have the spending key, 
             is required.
            : Since this is in the RPC code, pirated and the pirate-cli can also use the z_sendmany()
              command. Pirated & pirate-cli reads its config from PIRATE.conf, but the offline
              signing option is currently only available for the Qt GUI code.             