### PR TITLE
Transaction expired error message

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -1033,10 +1033,8 @@ WalletModel::SendCoinsReturn WalletModel::zsendCoins(WalletModelZTransaction &tr
           }
           else
           {
+            //Specific for the off-line transactions. Normal 'online' transactions won't see this
             transaction.setZSignOfflineTransaction("Could not find z_sign_offline in the result: "+sResult);
-            qsResult=QString::asprintf("Could not find z_sign_offline in the result: %s",sResult.c_str());
-            Q_EMIT coinsZSent(operationId);
-            return SendCoinsReturn(TransactionCreationFailed,qsResult);
           }
           iCounter=11; //exit polling loop
           break;

--- a/src/qt/zsendcoinsdialog.cpp
+++ b/src/qt/zsendcoinsdialog.cpp
@@ -345,8 +345,15 @@ void ZSendCoinsDialog::on_sendButton_clicked()
             try // Nice formatting for standard-format error
             {
                 int code = find_value(objError, "code").get_int();
-                std::string sMessage = find_value(objError, "message").get_str();
-
+                std::string sMessage="";
+                if (code==-26) //Transaction expired 
+                {
+                  sMessage = "The transaction expired";
+                }
+                else
+                {
+                  sMessage = find_value(objError, "message").get_str();
+                }
                 setResult("Transaction sending failed",sMessage.c_str() );
                 return;
             }

--- a/src/transaction_builder.cpp
+++ b/src/transaction_builder.cpp
@@ -118,6 +118,7 @@ TransactionBuilder::TransactionBuilder(
     uint32_t nExpiryHeight,
     uint32_t nVersionGroupId,
     int32_t nVersion,
+    int nBlockHeight,
     uint32_t branchId,
     uint8_t  cZip212Enabled)
 {
@@ -125,10 +126,12 @@ TransactionBuilder::TransactionBuilder(
     mtx.nExpiryHeight   = nExpiryHeight;
     mtx.nVersionGroupId = nVersionGroupId;
     mtx.nVersion        = nVersion;
+    nHeight             = nBlockHeight;
     consensusBranchId   = branchId;
     cZip212_enabled     = cZip212Enabled;
     
-    //printf("TransactionBuilder::TransactionBuilder(offline) values: fOverwintered=%u nExpiryHeight=%u nVersionGroupId=%u nVersion=%d\n",
+    //fprintf(stderr,"TransactionBuilder::TransactionBuilder(offline) values: (nHeight=%d), fOverwintered=%u, nExpiryHeight=%u, nVersionGroupId=%u, nVersion=%d\n",
+    //nHeight,
     //mtx.fOverwintered,
     //mtx.nExpiryHeight,
     //mtx.nVersionGroupId,

--- a/src/transaction_builder.h
+++ b/src/transaction_builder.h
@@ -140,7 +140,7 @@ class TransactionBuilder
 {
 private:
     Consensus::Params consensusParams;
-    int nHeight;
+    int nHeight=0;
     const CKeyStore* keystore;
     CMutableTransaction mtx;
     CAmount fee = 10000;
@@ -181,7 +181,7 @@ public:
     TransactionBuilder() {}
     TransactionBuilder(const Consensus::Params& consensusParams, int nHeight, CKeyStore* keyStore = nullptr);
     //For signing offline transactions:
-    TransactionBuilder(bool fOverwintered, uint32_t nExpiryHeight, uint32_t nVersionGroupId, int32_t nVersion, uint32_t branchId, uint8_t cZip212Enabled);
+    TransactionBuilder(bool fOverwintered, uint32_t nExpiryHeight, uint32_t nVersionGroupId, int32_t nVersion, int nBlockHeight, uint32_t branchId, uint8_t cZip212Enabled);
 
     ADD_SERIALIZE_METHODS;
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -5331,7 +5331,8 @@ UniValue z_sign_offline(const UniValue& params, bool fHelp, const CPubKey& mypk)
     }
 
     //------------------------------------------------------------------------------------------------------------
-    TransactionBuilder builder = TransactionBuilder(bMTX_overwintered,iMTX_ExpiryHeight,iMTX_VersionGroupID,iMTX_Version,branchId, (uint8_t)iZip212_enabled);
+    TransactionBuilder builder = TransactionBuilder(bMTX_overwintered,iMTX_ExpiryHeight,iMTX_VersionGroupID,iMTX_Version,\
+                                                    nextBlockHeight, branchId, (uint8_t)iZip212_enabled);
 
     //SCENARIO #0
     //printf("z_sign_offline()   14 AsyncRPCOperation_sendmany scenario 0\n"); fflush(stdout);


### PR DESCRIPTION
Fixed a bug where all transactions returned 'OK' to the GUI, which resulted in failed transactions incorrectly submitted to the blockchain miners for processing.

Expended the evaluation of the error status code to report when a transaction is too old to submit for processing (ExpiryHeight is 200 blocks by default, approx. 3.3 hours).

