### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/pirate_ci_ubunutu1804.yml
+++ b/.github/workflows/pirate_ci_ubunutu1804.yml
@@ -20,12 +20,12 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
         id: extract_branch
 
       - name: Shortify commit sha
         shell: bash
-        run: echo "##[set-output name=sha_short;]$(echo ${GITHUB_SHA::7})"
+        run: echo "sha_short=$(echo ${GITHUB_SHA::7})" >> $GITHUB_OUTPUT
         id: shortify_commit
 
       - name: Checkout code

--- a/.github/workflows/pirate_ci_ubunutu1804.yml
+++ b/.github/workflows/pirate_ci_ubunutu1804.yml
@@ -20,12 +20,12 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> "$GITHUB_OUTPUT"
         id: extract_branch
 
       - name: Shortify commit sha
         shell: bash
-        run: echo "sha_short=$(echo ${GITHUB_SHA::7})" >> $GITHUB_OUTPUT
+        run: echo "sha_short=$(echo ${GITHUB_SHA::7})" >> "$GITHUB_OUTPUT"
         id: shortify_commit
 
       - name: Checkout code

--- a/.github/workflows/pirate_ci_ubunutu2004.yml
+++ b/.github/workflows/pirate_ci_ubunutu2004.yml
@@ -20,12 +20,12 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
         id: extract_branch
 
       - name: Shortify commit sha
         shell: bash
-        run: echo "##[set-output name=sha_short;]$(echo ${GITHUB_SHA::7})"
+        run: echo "sha_short=$(echo ${GITHUB_SHA::7})" >> $GITHUB_OUTPUT
         id: shortify_commit
 
       - name: Checkout code

--- a/.github/workflows/pirate_ci_ubunutu2004.yml
+++ b/.github/workflows/pirate_ci_ubunutu2004.yml
@@ -20,12 +20,12 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> "$GITHUB_OUTPUT"
         id: extract_branch
 
       - name: Shortify commit sha
         shell: bash
-        run: echo "sha_short=$(echo ${GITHUB_SHA::7})" >> $GITHUB_OUTPUT
+        run: echo "sha_short=$(echo ${GITHUB_SHA::7})" >> "$GITHUB_OUTPUT"
         id: shortify_commit
 
       - name: Checkout code


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


