### PR TITLE
Adjust CLI argument handling for z_getbalances

### DIFF
--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -145,6 +145,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "z_listunspent", 2 },
     { "z_listunspent", 3 },
     { "z_getbalance", 1},
+    { "z_getbalances", 0},
     { "z_getbalances", 1},
     { "z_gettotalbalance", 0},
     { "z_gettotalbalance", 1},

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3873,7 +3873,7 @@ UniValue z_getbalances(const UniValue& params, bool fHelp, const CPubKey& mypk)
 
     if (fHelp || params.size() > 1)
         throw runtime_error(
-            "z_getbalances ( minconf includeWatchonly )\n"
+            "z_getbalances ( includeWatchonly )\n"
             "\nReturns array of wallet sapling addresses and balances.\n"
             "Results are an array of Objects, each of which has:\n"
             "{address, balance, unconfirmed, spendable}\n"


### PR DESCRIPTION
This corrects a bug in client.cpp where the `z_getbalances` function was set to accept the incorrect argument due to the configuration only having the single line, `{ "z_getbalances", 1}`. The `z_getbalances` command allows for an optional boolean argument, making it necessary to handle zero or one arguments. `z_getbalances` can now be correctly called with or without the optional Bool argument for including watchonly addresses

Corrected `z_getbalances` usage information. The error message has been corrected to show 'includeWatchonly' as the only expected parameter, where a second 'minconf' was also listed previously.