### PR TITLE
Fix pirate uri zsend tab auto open

### DIFF
--- a/src/qt/pirateoceangui.cpp
+++ b/src/qt/pirateoceangui.cpp
@@ -1335,10 +1335,16 @@ bool PirateOceanGUI::eventFilter(QObject *object, QEvent *event)
 
 bool PirateOceanGUI::handlePaymentRequest(const SendCoinsRecipient& recipient)
 {
+    // Automatically open the Z-send tab when receiving a Pirate URI
+    showNormalIfMinimized();
+    sleep(1);
+    showNormalIfMinimized();
+    gotoZSendCoinsPage();
+
     // URI has to be valid
     if (walletFrame && walletFrame->handlePaymentRequest(recipient))
     {
-        showNormalIfMinimized();
+        //showNormalIfMinimized();
         //gotoSendCoinsPage();
         printf("handlePaymentRequest() - true");
         return true;


### PR DESCRIPTION
Upon receipt of a Pirate URI, this fix restores the Pirate Chain window and automatically switches to the "Z-Send" tab. Without this, if Treasure Chest is not open to the Z-Send tab, the current Pirate URI handling doesn't work and the data doesn't get put in the "Z-Send" tab.