### PR TITLE
Fix build error -- add missing includes

### DIFF
--- a/src/crypto/equihash.cpp
+++ b/src/crypto/equihash.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <iostream>
 #include <stdexcept>
+#include <optional>
 
 /*
 #ifdef __APPLE__

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <vector>
 
+#include <functional>
 extern int nConnectTimeout;
 extern bool fNameLookup;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4410,20 +4410,23 @@ void CWallet::UpdateOrchardNullifierNoteMapWithTx(CWalletTx* wtx) {
 
                // The transaction would not have entered the wallet unless
                // it had been successfully decrypted previously.
-               assert(optDeserialized != std::nullopt);
-               auto note = optDeserialized.value().note().value();
+               if (optDeserialized != std::nullopt) {
+                   auto note = optDeserialized.value().note().value();
 
 
-               auto optNullifier = note.GetNullifier(extfvk.fvk);
-               if (!optNullifier) {
-                   // This should not happen.
-                   assert(false);
-               }
-               uint256 nullifier = optNullifier.value();
-               mapOrchardNullifiersToNotes[nullifier] = op;
-               mapArcOrchardOutPoints[nullifier] = op;
-               item.second.nullifier = nullifier;
-               LogPrintf("\nNullifier of Tx %s, output %i set with Position %u and Nullifier %s\n\n", wtx->GetHash().ToString(), op.n, position, nullifier.ToString());
+                   auto optNullifier = note.GetNullifier(extfvk.fvk);
+                   if (!optNullifier) {
+                       // This should not happen.
+                       assert(false);
+                   }
+                   uint256 nullifier = optNullifier.value();
+                   mapOrchardNullifiersToNotes[nullifier] = op;
+                   mapArcOrchardOutPoints[nullifier] = op;
+                   item.second.nullifier = nullifier;
+                   LogPrintf("\nNullifier of Tx %s, output %i set with Position %u and Nullifier %s\n\n", wtx->GetHash().ToString(), op.n, position, nullifier.ToString());
+              } else {
+                   LogPrintf("\nError Setting Nullifier of Tx %s, output %i set with Position %u\n\n", wtx->GetHash().ToString(), op.n, position);
+              }
            }
        }
    }


### PR DESCRIPTION
Building on Ubuntu 22.04 with g++ 12.3.0
The zcutil/build-qt-linux.sh fails, referring to function calls, for which their header files were not included.
  